### PR TITLE
fix: add slot to `<MarkdownContent>` override

### DIFF
--- a/src/components/starlight/MarkdownContent.astro
+++ b/src/components/starlight/MarkdownContent.astro
@@ -18,4 +18,4 @@ const { astroRange } = Astro.props.entry.data
 	)
 }
 
-<Default {...Astro.props} />
+<Default {...Astro.props}><slot /></Default>


### PR DESCRIPTION
- Closes #34

This PR fixes an issue introduced in one of the commit of #28 and I guess went unnoticed. The `<MarkdownContent>` override does not include a `<slot />` for the default Starlight component so the component cannot render any child elements passed to it.

The pattern is described in the ["Reuse a built-in component" guide](https://starlight.astro.build/guides/overriding-components/#reuse-a-built-in-component) of the Starlight documentation.