### PR TITLE
fix: astro version check

### DIFF
--- a/src/components/starlight/MarkdownContent.astro
+++ b/src/components/starlight/MarkdownContent.astro
@@ -6,14 +6,15 @@ import { coerce, satisfies } from 'semver'
 import pkg from 'package.json'
 
 const { astroRange } = Astro.props.entry.data
-const coerceVersion = coerce(pkg.dependencies.astro)?.version
+const astroVersion = coerce(pkg.dependencies.astro)?.version
+const outRange = astroRange && astroVersion && !satisfies(astroVersion, astroRange)
 ---
 
 {
 	// only show if the range is specified, and is not satisfied by the latest version
-	astroRange && coerceVersion && !satisfies(coerceVersion, astroRange) && (
+	outRange && (
 		<Aside type="caution">
-			This guide was written for Astro {coerce(astroRange)} and may not work
+			This guide was written for Astro {astroRange} and may not work
 			with more recent versions of Astro.
 		</Aside>
 	)

--- a/src/components/starlight/MarkdownContent.astro
+++ b/src/components/starlight/MarkdownContent.astro
@@ -7,6 +7,7 @@ import pkg from 'package.json'
 
 const { astroRange } = Astro.props.entry.data
 const astroVersion = minVersion(pkg.dependencies.astro)?.version
+// check if the Astro version is less than the required range.
 const outRange = astroRange && astroVersion && outside(astroVersion, astroRange, '>')
 const semverUrl = `https://semver.otterlord.dev/?package=astro&range=${astroRange}&filter=on`
 ---

--- a/src/components/starlight/MarkdownContent.astro
+++ b/src/components/starlight/MarkdownContent.astro
@@ -2,11 +2,11 @@
 import type { Props } from '@astrojs/starlight/props'
 import Default from '@astrojs/starlight/components/MarkdownContent.astro'
 import { Aside } from '@astrojs/starlight/components'
-import { coerce, satisfies } from 'semver'
+import { minVersion, satisfies } from 'semver'
 import pkg from 'package.json'
 
 const { astroRange } = Astro.props.entry.data
-const astroVersion = coerce(pkg.dependencies.astro)?.version
+const astroVersion = minVersion(pkg.dependencies.astro)?.version
 const outRange = astroRange && astroVersion && !satisfies(astroVersion, astroRange)
 ---
 

--- a/src/components/starlight/MarkdownContent.astro
+++ b/src/components/starlight/MarkdownContent.astro
@@ -6,11 +6,12 @@ import { coerce, satisfies } from 'semver'
 import pkg from 'package.json'
 
 const { astroRange } = Astro.props.entry.data
+const coerceVersion = coerce(pkg.dependencies.astro)?.version
 ---
 
 {
 	// only show if the range is specified, and is not satisfied by the latest version
-	astroRange && !satisfies(pkg.dependencies.astro, astroRange) && (
+	astroRange && coerceVersion && !satisfies(coerceVersion, astroRange) && (
 		<Aside type="caution">
 			This guide was written for Astro {coerce(astroRange)} and may not work
 			with more recent versions of Astro.

--- a/src/components/starlight/MarkdownContent.astro
+++ b/src/components/starlight/MarkdownContent.astro
@@ -2,20 +2,20 @@
 import type { Props } from '@astrojs/starlight/props'
 import Default from '@astrojs/starlight/components/MarkdownContent.astro'
 import { Aside } from '@astrojs/starlight/components'
-import { minVersion, satisfies } from 'semver'
+import { minVersion, outside } from 'semver'
 import pkg from 'package.json'
 
 const { astroRange } = Astro.props.entry.data
 const astroVersion = minVersion(pkg.dependencies.astro)?.version
-const outRange = astroRange && astroVersion && !satisfies(astroVersion, astroRange)
+const outRange = astroRange && astroVersion && outside(astroVersion, astroRange, '>')
+const semverUrl = `https://semver.otterlord.dev/?package=astro&range=${astroRange}&filter=on`
 ---
 
 {
-	// only show if the range is specified, and is not satisfied by the latest version
+	// only show if the Astro version is less than the required range.
 	outRange && (
 		<Aside type="caution">
-			This guide was written for Astro {astroRange} and may not work
-			with more recent versions of Astro.
+			This guide was written for Astro <a href={semverUrl}>{astroRange}</a> and may not work for versions outside of that range.
 		</Aside>
 	)
 }

--- a/src/components/starlight/MarkdownContent.astro
+++ b/src/components/starlight/MarkdownContent.astro
@@ -16,7 +16,8 @@ const semverUrl = `https://semver.otterlord.dev/?package=astro&range=${astroRang
 	// only show if the Astro version is less than the required range.
 	outRange && (
 		<Aside type="caution">
-			This guide was written for Astro <a href={semverUrl}>{astroRange}</a> and may not work for versions outside of that range.
+			This guide was written for Astro <a href={semverUrl}>{astroRange}</a> and may not work for versions outside of that range.<br />
+			We always try to keep our tips up to date, but if you see this caution, please open an <a href="https://github.com/astrolicious/astro-tips.dev/issues">issue</a> to let us know.
 		</Aside>
 	)
 }

--- a/src/components/starlight/PageTitle.astro
+++ b/src/components/starlight/PageTitle.astro
@@ -4,6 +4,7 @@ import Default from '@astrojs/starlight/components/PageTitle.astro'
 import { Icon } from '@astrojs/starlight/components'
 
 const { astroRange } = Astro.props.entry.data
+const semverUrl = `https://semver.otterlord.dev/?package=astro&range=${astroRange}&filter=on`
 ---
 
 <Default {...Astro.props} />
@@ -14,7 +15,7 @@ const { astroRange } = Astro.props.entry.data
       <p>
         <span class="sr-only">Astro</span>
         <Icon name="astro" />
-        <span title={`Compatible with Astro version ${astroRange}`}>{astroRange}</span>
+        <a href={semverUrl} title={`Compatible with Astro version ${astroRange}`}>{astroRange}</a>
       </p>
     </div>
   )

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,6 +1,7 @@
 import { defineCollection, z } from 'astro:content'
 import { docsSchema } from '@astrojs/starlight/schema'
-import { validRange } from 'semver'
+import { minVersion, outside, validRange } from 'semver'
+import pkg from 'package.json'
 
 export const collections = {
 	docs: defineCollection({
@@ -9,6 +10,11 @@ export const collections = {
 				astroRange: z
 					.string()
 					.refine(validRange, {message: 'Must be a valid semver range'})
+					.refine((range) => {
+						const astroVersion = minVersion(pkg.dependencies.astro)?.version
+						// check if range is less than the current astro version
+						return astroVersion && !outside(astroVersion, range, '<')
+					}, {message: 'Must be compatible with the current Astro version'})
 					.optional(),
 			}),
 		}),

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -12,7 +12,7 @@ export const collections = {
 					.refine(validRange, {message: 'Must be a valid semver range'})
 					.refine((range) => {
 						const astroVersion = minVersion(pkg.dependencies.astro)?.version
-						// check if range is less than the current astro version
+						// check if range is bigger than the current Astro version.
 						return astroVersion && !outside(astroVersion, range, '<')
 					}, {message: 'Must be compatible with the current Astro version'})
 					.optional(),

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -3,6 +3,8 @@ import { docsSchema } from '@astrojs/starlight/schema'
 import { minVersion, outside, validRange } from 'semver'
 import pkg from 'package.json'
 
+const astroVersion = minVersion(pkg.dependencies.astro)?.version
+
 export const collections = {
 	docs: defineCollection({
 		schema: docsSchema({
@@ -11,10 +13,9 @@ export const collections = {
 					.string()
 					.refine(validRange, {message: 'Must be a valid semver range'})
 					.refine((range) => {
-						const astroVersion = minVersion(pkg.dependencies.astro)?.version
 						// check if range is bigger than the current Astro version.
 						return astroVersion && !outside(astroVersion, range, '<')
-					}, {message: 'Must be compatible with the current Astro version'})
+					}, {message: `'astroRange' must be compatible with the current released Astro version: '${astroVersion}'`})
 					.optional(),
 			}),
 		}),


### PR DESCRIPTION
Fix to not show the warning for all matching versions.

`satisfies()` expects to receive the following.

> satisfies(version, range): Return true if the version satisfies the range.

So, Convert using coerce.

> coerce(version, options): Coerces a string to semver if possible

```js
console.log(semver.coerce('^4.5.9')) // 4.5.9
```


https://github.com/npm/node-semver