### PR TITLE
fix: astro range link unstyled on safari

### DIFF
--- a/src/components/starlight/PageTitle.astro
+++ b/src/components/starlight/PageTitle.astro
@@ -36,4 +36,7 @@ const semverUrl = `https://semver.otterlord.dev/?package=astro&range=${astroRang
 		gap: 0.5rem 1rem;
 		font-size: var(--sl-text-xs);
 	}
+	a {
+		color: var(--sl-color-text-accent);
+	}
 </style>


### PR DESCRIPTION
The semver link at top of pages wasn't styled properly on safari 

![image](https://github.com/astrolicious/astro-tips.dev/assets/115520730/b6683dd3-0028-4ffa-8792-0efc95b7b11c)


Not a starlight expert so maybe there's a better way to do this but, from my testing this works