### PR TITLE
Fix: discord link in starlight config

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
       title: "Astro Tips",
       social: {
         github: "https://github.com/astrolicious/astro-tips.dev",
-        discord: "https://astro.build/chat",
+        discord: "https://chat.astrolicious.dev/",
       },
       sidebar: [
         {


### PR DESCRIPTION
this link controls the discord icon at top right of pages