### PR TITLE
fix: dark-mode examples button

### DIFF
--- a/examples/dark-mode/src/components/ThemeToggleButton.astro
+++ b/examples/dark-mode/src/components/ThemeToggleButton.astro
@@ -4,62 +4,89 @@
  * If the default theme is auto it will toggle between auto and the opposite of the systemTheme
  *
  * If the default theme is not auto it will never enter auto mode
+ *
+ * Set the themeIconRelationship to determine the behavior of the icon, match will have moon icon displayed while dark theme is active
+ *
  */
+
+ type Props = {
+  themeIconRelationship?: "match" | "opposite" | undefined;
+};
+
+const { themeIconRelationship = "opposite" } = Astro.props;
 ---
 
-<button is="theme-toggle-button"></button>
-<style>
-  button[is="theme-toggle-button"] {
-    background-color: transparent;
-    border: none;
-    color: inherit;
-    width: 2.5rem;
-    height: auto;
-    cursor: pointer;
-  }
-</style>
-<noscript>
-  <style>
-    button[is="theme-toggle-button"] {
-      visibility: hidden;
-    }
-  </style>
-</noscript>
-<script is:inline>
+<theme-toggle-button></theme-toggle-button>
+
+<script is:inline data-theme-icon-relationship={themeIconRelationship}>
   if (!customElements.get("theme-toggle-button")) {
-    class ThemeToggleButton extends HTMLButtonElement {
+    const themeIconRelationship = document.currentScript.getAttribute(
+      "data-theme-icon-relationship"
+    );
+    class ThemeToggleButton extends HTMLElement {
       constructor() {
         super();
+        this.attachShadow({ mode: "open" });
+        this.toggleTheme = this.toggleTheme.bind(this);
+        this.updateThemeIconAndAriaLabel =
+          this.updateThemeIconAndAriaLabel.bind(this);
       }
 
       connectedCallback() {
         this.render();
         this.bindEvents();
-        this.updateAriaLabel();
+        this.updateThemeIconAndAriaLabel();
+      }
+
+      disconnectedCallback() {
+        this.removeEventListener("click", this.toggleTheme);
+        document.removeEventListener(
+          "theme-changed",
+          this.updateThemeIconAndAriaLabel
+        );
       }
 
       render() {
-        this.innerHTML = `
-          <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" id="moon" aria-hidden="true">
-            <path
-              d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"
-            ></path>
-          </svg>
-          <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" id="sun" aria-hidden="true">
-            <path
-              d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
-            ></path>
-          </svg>
-        `;
-        this.updateThemeIcon();
+        this.shadowRoot.innerHTML = `
+                <style>
+                    button {
+                        background-color: transparent;
+                        border: none;
+                        color: inherit;
+                        width: 2.5rem;
+                        height: auto;
+                        cursor: pointer;
+                    }
+                    svg {
+                      stroke: currentColor;
+                      fill: none;
+                      stroke-width: 1.5;
+                    }
+                    svg path {
+                      stroke-linecap: round;
+                      stroke-linejoin: round;
+                    }
+                </style>
+                <button>
+                    <svg viewBox="0 0 24 24" id="moon" aria-hidden="true">
+                        <path d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"></path>
+                    </svg>
+                    <svg viewBox="0 0 24 24" id="sun" aria-hidden="true">
+                        <path d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"></path>
+                    </svg>
+                </button>
+                `;
+        this.updateThemeIconAndAriaLabel();
       }
 
       bindEvents() {
-        this.addEventListener("click", () => this.toggleTheme());
-        document.addEventListener("theme-changed", () => {
-          this.updateThemeIcon();
-          this.updateAriaLabel();
-        });
+        this.addEventListener("click", this.toggleTheme);
+        document.addEventListener("theme-changed", (e) =>
+          this.updateThemeIconAndAriaLabel(
+            e.detail.currentTheme,
+            e.detail.systemTheme
+          )
+        );
       }
 
       toggleTheme() {
@@ -69,31 +96,41 @@
         let newTheme;
 
         if (defaultTheme === "auto") {
-          if (currentTheme === "auto" || currentTheme === systemTheme) {
-            newTheme = systemTheme === "dark" ? "light" : "dark";
-          } else {
-            newTheme = "auto";
-          }
+          newTheme =
+            currentTheme === "auto" || currentTheme === systemTheme
+              ? systemTheme === "dark"
+                ? "light"
+                : "dark"
+              : "auto";
         } else {
-          if (currentTheme === defaultTheme) {
-            newTheme = defaultTheme === "dark" ? "light" : "dark";
-          } else if (currentTheme === "auto") {
-            newTheme = systemTheme === "dark" ? "light" : "dark";
-          } else {
-            newTheme = defaultTheme;
-          }
+          newTheme =
+            currentTheme === defaultTheme
+              ? defaultTheme === "dark"
+                ? "light"
+                : "dark"
+              : currentTheme === "auto"
+                ? systemTheme === "dark"
+                  ? "light"
+                  : "dark"
+                : defaultTheme;
         }
 
         theme.setTheme(newTheme);
-        this.updateThemeIcon();
-        this.updateAriaLabel();
+        this.updateThemeIconAndAriaLabel(newTheme, systemTheme);
       }
 
-      updateThemeIcon() {
-        const currentTheme = theme.getTheme();
-        const systemTheme = theme.getSystemTheme();
-        const sunIcon = this.querySelector("#sun");
-        const moonIcon = this.querySelector("#moon");
+      updateThemeIconAndAriaLabel(
+        currentTheme = theme.getTheme(),
+        systemTheme = theme.getSystemTheme()
+      ) {
+        const sunIcon =
+          themeIconRelationship === "opposite"
+            ? this.shadowRoot.querySelector("#sun")
+            : this.shadowRoot.querySelector("#moon");
+        const moonIcon =
+          themeIconRelationship === "opposite"
+            ? this.shadowRoot.querySelector("#moon")
+            : this.shadowRoot.querySelector("#sun");
 
         sunIcon.style.display =
           currentTheme === "dark" ||
@@ -105,22 +142,20 @@
           (currentTheme === "auto" && systemTheme === "light")
             ? "block"
             : "none";
-      }
-
-      updateAriaLabel() {
-        const currentTheme = theme.getTheme();
-        const systemTheme = theme.getSystemTheme();
         const newMode =
           currentTheme === "dark" ||
           (currentTheme === "auto" && systemTheme === "dark")
             ? "light"
             : "dark";
-        this.ariaLabel = `Theme toggle button: click to activate ${newMode} mode`;
+        this.shadowRoot
+          .querySelector("button")
+          .setAttribute(
+            "aria-label",
+            `Theme toggle button: click to activate ${newMode} mode`
+          );
       }
     }
 
-    customElements.define("theme-toggle-button", ThemeToggleButton, {
-      extends: "button",
-    });
+    customElements.define("theme-toggle-button", ThemeToggleButton);
   }
 </script>


### PR DESCRIPTION
Turns out you can't extend builtin elements in safari 

Took the opportunity to add a prop to set toggle the relationship

Ensures that the aria is correctly updated every time theme changes

Slight refactor to reduce the amount of theme.method() as well 