### PR TITLE
Update biome.json

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,7 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "ignore": [".prettierrc.mjs", ".prettierignore", "*.astro"]
+    "ignore": [".prettierrc.mjs", ".prettierignore", "*.astro", "examples/shadcn-ui/*"]
   },
   "formatter": {
     "lineWidth": 100


### PR DESCRIPTION
Ignore Shadcn-ui example due to Shadcn itself creating a biome error

lint/a11y/useSemanticElements

comes up due to Shadcn's use of role in it's carousel 