### PR TITLE
Adding animate on scroll recipe as external example

### DIFF
--- a/src/content/resources/animate-on-scroll.json
+++ b/src/content/resources/animate-on-scroll.json
@@ -1,0 +1,7 @@
+{
+    "tags": ["animation"],
+    "title": "Using Animate On Scroll (AOS) in Astro: A Step-by-Step Guide",
+    "link": "https://www.launchfa.st/blog/aos-astro",
+    "updated": "2024-04-16"
+}
+  


### PR DESCRIPTION
This is in response to Astro's doc community issue: https://github.com/withastro/docs/issues/10092

This adds the animate on scroll recipe to external resources via a json file