### PR TITLE
fix: Lucia username and passoword auth broken link

### DIFF
--- a/src/content/resources/username-password-lucia.json
+++ b/src/content/resources/username-password-lucia.json
@@ -1,6 +1,6 @@
 {
   "tags": ["auth"],
   "title": "Add username and password authentication with Lucia",
-  "link": "https://lucia-auth.com/tutorials/username-and-password/astro",
+  "link": "https://v3.lucia-auth.com/tutorials/username-and-password/astro",
   "updated": "2023-09-15"
 }


### PR DESCRIPTION
This fixes broken link as intended in [this pr](https://github.com/withastro/docs/pull/10098) and [this issue](https://github.com/withastro/docs/issues/10092)