### PR TITLE
Fix: Updates Kevin Link

### DIFF
--- a/src/content/resources/dark-mode-tailwindcss.json
+++ b/src/content/resources/dark-mode-tailwindcss.json
@@ -1,6 +1,6 @@
 {
   "tags": ["CSS"],
   "title": "Add dark mode to Astro with Tailwind CSS",
-  "link": "https://www.kevinzunigacuellar.com/blog/dark-mode-in-astro/",
+  "link": "https://www.kevinzc.com/blog/dark-mode-in-astro/",
   "updated": "2022-05-04"
 }


### PR DESCRIPTION
Updates the link to Kevin Zuniga's site listed in `dark-mode-tailwindcss.json` to his new URL so people don't get directed to the gambling site that snagged up the old domain